### PR TITLE
Expose lock table name

### DIFF
--- a/config/cache.php
+++ b/config/cache.php
@@ -41,6 +41,7 @@ return [
         'database' => [
             'driver' => 'database',
             'table' => env('DB_CACHE_TABLE', 'cache'),
+            'lock_table' => env('DB_CACHE_LOCK_TABLE'),
             'connection' => env('DB_CACHE_CONNECTION'),
             'lock_connection' => env('DB_CACHE_LOCK_CONNECTION'),
         ],


### PR DESCRIPTION
I wasn't immediately obvious that the lock table name could be changed because the option isn't exposed by default in the configuration.



Since [I had to do a bit of digging](https://github.com/laravel/framework/blob/02a0b5f6f83b13ea750f959364aefa324441a354/src/Illuminate/Cache/CacheManager.php#L212-L231) to find the option, I thought this would be a welcome addition.